### PR TITLE
Use Supabase in testimonial widget

### DIFF
--- a/src/components/widgets/TestimonialCarouselWidget.jsx
+++ b/src/components/widgets/TestimonialCarouselWidget.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import * as FiIcons from 'react-icons/fi'
 import SafeIcon from '../../common/SafeIcon'
+import { getApprovedTestimonials } from '../../lib/reviews'
 
 const { FiChevronLeft, FiChevronRight, FiStar } = FiIcons
 
@@ -16,25 +17,26 @@ const TestimonialCarouselWidget = ({ config }) => {
     animation,
     autoPlay,
     interval,
-    showRatings
+    showRatings,
+    limit = 5
   } = config
 
   const [testimonials, setTestimonials] = useState([])
   const [currentIndex, setCurrentIndex] = useState(0)
 
-  // Load testimonials from your API/database
+  // Load testimonials from Supabase
   useEffect(() => {
-    // TODO: Implement testimonial loading
-    setTestimonials([
-      {
-        id: 1,
-        text: "Working with this team has transformed our financial future...",
-        author: "John D.",
-        rating: 5
-      },
-      // Add more testimonials
-    ])
-  }, [])
+    const loadTestimonials = async () => {
+      try {
+        const data = await getApprovedTestimonials(limit)
+        setTestimonials(data)
+      } catch (error) {
+        console.error('Error loading testimonials:', error)
+      }
+    }
+
+    loadTestimonials()
+  }, [limit])
 
   // Auto-play functionality
   useEffect(() => {

--- a/src/lib/widgets/types.js
+++ b/src/lib/widgets/types.js
@@ -93,7 +93,8 @@ export const WIDGET_LIBRARY = {
       subtitle: 'Hear from the people we\'ve helped',
       autoPlay: true,
       interval: 5000,
-      showRatings: true
+      showRatings: true,
+      limit: 5
     }
   },
   


### PR DESCRIPTION
## Summary
- hook up `TestimonialCarouselWidget` to Supabase
- add `limit` option for testimonial carousel widget

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c2ade8fb0833394d8b6731934dd3b