### PR TITLE
Fix contrast and update branding

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -19,9 +19,11 @@ const Header = () => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center">
-            <h1 className="text-2xl font-bold text-white">
-              Prosperity Leaders™
-            </h1>
+            <img
+              src="https://media.publit.io/file/ProsperityWebApp/Prosperity-Elephant-WIDE-BLUEPNG.png"
+              alt="Prosperity Leaders"
+              className="h-8 w-auto"
+            />
             <span className="ml-2 text-sm text-white/70">Platform</span>
           </div>
 

--- a/src/components/layout/MainNav.jsx
+++ b/src/components/layout/MainNav.jsx
@@ -45,11 +45,12 @@ const MainNav = ({ variant = 'public' }) => {
     return (
       <nav className="w-64 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700">
         <div className="p-6">
-          <Link to="/" className="flex items-center space-x-2">
-            <SafeIcon icon={FiBox} className="w-6 h-6 text-picton-blue" />
-            <span className="text-lg font-bold text-polynesian-blue dark:text-white">
-              Prosperity Leaders™
-            </span>
+          <Link to="/" className="flex items-center">
+            <img
+              src="https://media.publit.io/file/ProsperityWebApp/Prosperity-Elephant-WIDE-BLUEPNG.png"
+              alt="Prosperity Leaders"
+              className="h-8 w-auto"
+            />
           </Link>
         </div>
         <div className="px-4 py-2">
@@ -97,10 +98,12 @@ const MainNav = ({ variant = 'public' }) => {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center">
-              <Link to="/" className="flex items-center">
-                <h1 className="text-2xl font-bold text-white">
-                  Prosperity Leaders™
-                </h1>
+              <Link to="/" className="flex items-center space-x-2">
+                <img
+                  src="https://media.publit.io/file/ProsperityWebApp/Prosperity-Elephant-WIDE-BLUEPNG.png"
+                  alt="Prosperity Leaders"
+                  className="h-8 w-auto"
+                />
                 <span className="ml-2 text-sm text-white/70">Platform</span>
               </Link>
             </div>
@@ -171,7 +174,11 @@ const MainNav = ({ variant = 'public' }) => {
         <div className="flex justify-between items-center">
           {/* Logo */}
           <Link to="/" className="flex items-center">
-            <span className="text-white font-bold text-xl">Prosperity Leaders™</span>
+            <img
+              src="https://media.publit.io/file/ProsperityWebApp/Prosperity-Elephant-WIDE-BLUEPNG.png"
+              alt="Prosperity Leaders"
+              className="h-8 w-auto"
+            />
           </Link>
           
           {/* Desktop Navigation */}

--- a/src/components/pages/Home.jsx
+++ b/src/components/pages/Home.jsx
@@ -71,7 +71,7 @@ const Home = () => {
       {/* Hero Section */}
       <section
         ref={heroRef}
-        className="relative bg-gradient-to-br from-primary-bg to-polynesian-blue text-white pt-32 pb-24 md:pt-40 md:pb-32 overflow-hidden"
+        className="relative bg-gradient-to-br from-picton-blue to-polynesian-blue text-white pt-32 pb-24 md:pt-40 md:pb-32 overflow-hidden"
       >
         {/* Decorative Background Elements */}
         <div className="absolute inset-0 overflow-hidden">
@@ -105,10 +105,10 @@ const Home = () => {
             animate={heroInView ? "visible" : "hidden"}
             variants={fadeIn}
           >
-            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6 leading-tight">
+            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6 leading-tight drop-shadow-lg">
               {content.hero?.headline || 'Welcome to Prosperity Leaders™'}
             </h1>
-            <p className="text-lg md:text-xl text-white/90 mb-10 max-w-2xl mx-auto">
+            <p className="text-lg md:text-xl text-white/90 mb-10 max-w-2xl mx-auto drop-shadow">
               {content.hero?.subheadline || 'Empowering families and professionals to grow, protect, and multiply their wealth — with clarity and purpose.'}
             </p>
             

--- a/src/components/sections/SectionAbout.jsx
+++ b/src/components/sections/SectionAbout.jsx
@@ -42,9 +42,9 @@ const SectionAbout = ({ content }) => {
             <div className="absolute -top-10 -left-10 w-64 h-64 bg-picton-blue/5 rounded-full z-0"></div>
             <div className="absolute -bottom-8 -right-8 w-40 h-40 bg-secondary-cta/5 rounded-full z-0"></div>
             
-            <img 
-              src={content.image_url || "https://images.unsplash.com/photo-1573497491765-dccce02b29df?w=800&auto=format&fit=crop&q=80"}
-              alt="About Prosperity Leaders" 
+            <img
+              src={content.image_url || "https://media.publit.io/file/ProsperityWebApp/SebasJenny.jpg"}
+              alt="About Prosperity Leaders"
               className="rounded-lg shadow-xl w-full h-auto object-cover z-10 relative"
             />
           </div>


### PR DESCRIPTION
## Summary
- improve hero text readability with darker gradient and drop shadows
- replace header logos with elephant branding image
- update About Us default image

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c3800c1a48333a28656fc8f009388