### PR TITLE
Redirect login to Clerk subdomain

### DIFF
--- a/src/components/layout/MainNav.jsx
+++ b/src/components/layout/MainNav.jsx
@@ -239,12 +239,12 @@ const MainNav = ({ variant = 'public' }) => {
                 )}
               </div>
             ) : (
-              <Link
-                to="/login"
+              <a
+                href="https://accounts.prosperityleaders.net/sign-in?redirect_url=https://prosperityleaders.net/#/dashboard"
                 className="bg-[#3AA0FF] hover:bg-[#3AA0FF]/90 text-white py-2 px-4 rounded-md transition-colors"
               >
                 Login
-              </Link>
+              </a>
             )}
           </div>
           
@@ -352,13 +352,13 @@ const MainNav = ({ variant = 'public' }) => {
                     </button>
                   </>
                 ) : (
-                  <Link
-                    to="/login"
+                  <a
+                    href="https://accounts.prosperityleaders.net/sign-in?redirect_url=https://prosperityleaders.net/#/dashboard"
                     className="bg-[#3AA0FF] hover:bg-[#3AA0FF]/90 text-white py-2 px-4 rounded-md transition-colors inline-block"
                     onClick={() => setMobileMenuOpen(false)}
                   >
                     Login
-                  </Link>
+                  </a>
                 )}
               </div>
             </div>

--- a/src/components/pages/Login.jsx
+++ b/src/components/pages/Login.jsx
@@ -1,12 +1,12 @@
-import React from 'react'
-import { SignIn } from '@clerk/clerk-react'
+import React, { useEffect } from 'react'
 
 const Login = () => {
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-anti-flash-white to-white">
-      <SignIn routing="hash" path="/login" signUpUrl="/signup" />
-    </div>
-  )
+  useEffect(() => {
+    window.location.href =
+      'https://accounts.prosperityleaders.net/sign-in?redirect_url=https://prosperityleaders.net/#/dashboard'
+  }, [])
+
+  return null
 }
 
 export default Login


### PR DESCRIPTION
## Summary
- redirect `/login` page to Clerk sign-in hosted on accounts.prosperityleaders.net
- update navigation Login buttons to link to the external sign-in page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687c47035fcc8333bd1f3b78a1815b57