### PR TITLE
Remove redirect_url from login routes

### DIFF
--- a/src/components/layout/MainNav.jsx
+++ b/src/components/layout/MainNav.jsx
@@ -240,7 +240,7 @@ const MainNav = ({ variant = 'public' }) => {
               </div>
             ) : (
               <a
-                href="https://accounts.prosperityleaders.net/sign-in?redirect_url=https://prosperityleaders.net/#/dashboard"
+                href="https://accounts.prosperityleaders.net/sign-in"
                 className="bg-[#3AA0FF] hover:bg-[#3AA0FF]/90 text-white py-2 px-4 rounded-md transition-colors"
               >
                 Login
@@ -353,7 +353,7 @@ const MainNav = ({ variant = 'public' }) => {
                   </>
                 ) : (
                   <a
-                    href="https://accounts.prosperityleaders.net/sign-in?redirect_url=https://prosperityleaders.net/#/dashboard"
+                    href="https://accounts.prosperityleaders.net/sign-in"
                     className="bg-[#3AA0FF] hover:bg-[#3AA0FF]/90 text-white py-2 px-4 rounded-md transition-colors inline-block"
                     onClick={() => setMobileMenuOpen(false)}
                   >

--- a/src/components/pages/Login.jsx
+++ b/src/components/pages/Login.jsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react'
 const Login = () => {
   useEffect(() => {
     window.location.href =
-      'https://accounts.prosperityleaders.net/sign-in?redirect_url=https://prosperityleaders.net/#/dashboard'
+      'https://accounts.prosperityleaders.net/sign-in'
   }, [])
 
   return null


### PR DESCRIPTION
## Summary
- update login links in `MainNav` to drop redirect query
- change `Login` page redirect to plain sign-in URL

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c51e9b7c4833389e0ee2c5973a186