### PR TITLE
Fix Vite externalization for Clerk

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@clerk/clerk-react": "^5.35.3",
+    "@clerk/clerk-browser": "^5.35.3",
     "@supabase/supabase-js": "^2.39.0",
     "date-fns": "^2.30.0",
     "framer-motion": "^11.0.8",

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,8 +10,11 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src')
     }
   },
-   build: {
+  build: {
     outDir: 'dist',
-    sourcemap: true
+    sourcemap: true,
+    rollupOptions: {
+      external: ['@clerk/clerk-browser']
+    }
   },
 });


### PR DESCRIPTION
## Summary
- add `@clerk/clerk-browser` dependency
- instruct Vite to treat `@clerk/clerk-browser` as an external module

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c6f1320488333b4a76c38ad912059