### PR TITLE
Remove Clerk external option

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -12,9 +12,6 @@ export default defineConfig({
   },
    build: {
     outDir: 'dist',
-    sourcemap: true,
-    rollupOptions: {
-      external: ['@clerk/clerk-js']
-    }
+    sourcemap: true
   },
 });


### PR DESCRIPTION
## Summary
- remove Clerk JS from Rollup external list in `vite.config.js`

## Testing
- `npm run build` *(fails: getToken is not exported by @clerk/clerk-js)*

------
https://chatgpt.com/codex/tasks/task_e_687c7ed718188333b6c9bc2e050f58ce