### PR TITLE
Guard PagesManager against invalid data

### DIFF
--- a/src/components/dashboard/PagesManager.jsx
+++ b/src/components/dashboard/PagesManager.jsx
@@ -99,10 +99,10 @@ const PagesManager = () => {
       </div>
 
       <div className="space-y-4">
-        {pages.length === 0 ? (
+        {!Array.isArray(pages) || pages.length === 0 ? (
           <div className="text-center py-12">
             <SafeIcon icon={FiGlobe} className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-            <p className="text-polynesian-blue/70">No pages created yet</p>
+            <p className="text-polynesian-blue/70">No pages found</p>
             <p className="text-sm text-polynesian-blue/50 mt-1">Create your first landing page to get started</p>
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- prevent crash in `PagesManager` by verifying `pages` is an array before mapping

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687d36f8ad048333a8f537889484be37