### PR TITLE
Fix Clerk token handling with Supabase JS v2

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -92,10 +92,10 @@ function App() {
       if (isSignedIn) {
         const token = await getToken({ template: 'supabase' })
         if (token) {
-          setSupabaseAuth(token)
+          await setSupabaseAuth(token)
         }
       } else {
-        setSupabaseAuth(null)
+        await setSupabaseAuth(null)
       }
     }
     applyToken()

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -23,8 +23,12 @@ if (
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
 
 // Helper to set the JWT from Clerk once the user is signed in
-export const setSupabaseAuth = (token) => {
-  supabase.auth.setAuth(token)
+export const setSupabaseAuth = async (token) => {
+  if (token) {
+    await supabase.auth.setSession({ access_token: token, refresh_token: '' })
+  } else {
+    await supabase.auth.signOut()
+  }
 }
 
 export const getSupabaseClient = async () => supabase


### PR DESCRIPTION
## Summary
- update `setSupabaseAuth` to use `supabase.auth.setSession`
- sign out via Supabase when no Clerk token is available
- await the async auth helper in `App` effect

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687d5861eaec8333937a6814a755517b