### PR TITLE
Remove deprecated Clerk JWT handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ file before starting the app.
    ```bash
    npm install @clerk/clerk-react@latest
    ```
+5. Enable the **Supabase** integration in the Clerk dashboard. This automatically
+   adds the required `role: "authenticated"` claim to session tokens so the app
+   can communicate with Supabase without manual JWT handling.
 
 ## Publit.io Setup
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,7 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { HashRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider, useAuth as useAuthContext } from './context/AuthContext'
 import { ThemeProvider } from './context/ThemeContext'
-import { useAuth as useClerkAuth } from '@clerk/clerk-react'
-import { setSupabaseAuth } from './lib/supabase.js'
 import DashboardLayout from './components/dashboard/DashboardLayout'
 import Dashboard from './components/pages/Dashboard'
 import ContentManager from './components/cms/ContentManager'
@@ -85,21 +83,6 @@ const AppRoutes = () => {
 }
 
 function App() {
-  const { isSignedIn, getToken } = useClerkAuth()
-
-  useEffect(() => {
-    const applyToken = async () => {
-      if (isSignedIn) {
-        const token = await getToken({ template: 'supabase' })
-        if (token) {
-          await setSupabaseAuth(token)
-        }
-      } else {
-        await setSupabaseAuth(null)
-      }
-    }
-    applyToken()
-  }, [isSignedIn, getToken])
 
   return (
     <AuthProvider>

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -22,15 +22,6 @@ if (
 // Singleton Supabase client shared across the app
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
 
-// Helper to set the JWT from Clerk once the user is signed in
-export const setSupabaseAuth = async (token) => {
-  if (token) {
-    await supabase.auth.setSession({ access_token: token, refresh_token: '' })
-  } else {
-    await supabase.auth.signOut()
-  }
-}
-
 export const getSupabaseClient = async () => supabase
 
 export async function getSiteContent() {


### PR DESCRIPTION
## Summary
- remove obsolete Clerk JWT token logic
- drop `setSupabaseAuth` helper
- document enabling Clerk's Supabase integration

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687de31bad508333ab67a547162ab282