### PR TITLE
Integrate Clerk session token with Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ file before starting the app.
 5. Enable the **Supabase** integration in the Clerk dashboard. This automatically
    adds the required `role: "authenticated"` claim to session tokens so the app
    can communicate with Supabase without manual JWT handling.
+6. The Supabase client fetches your session token via `getToken({ template: 'supabase' })`.
+   Ensure this token template is enabled in Clerk so API requests are authorized.
 
 ## Publit.io Setup
 

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,4 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
+import { getToken } from '@clerk/clerk-react'
+import { useMemo } from 'react'
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
@@ -20,7 +22,16 @@ if (
 }
 
 // Singleton Supabase client shared across the app
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: {
+    getSession: async () => {
+      const token = await getToken({ template: 'supabase' })
+      return { data: { session: token ? { access_token: token } : null } }
+    }
+  }
+})
+
+export const useSupabaseClient = () => useMemo(() => supabase, [])
 
 export const getSupabaseClient = async () => supabase
 


### PR DESCRIPTION
## Summary
- fetch Clerk session token when creating Supabase client
- expose the configured client with `useSupabaseClient`
- document Clerk token requirement in README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687de94561f48333a4f37944c6285035