### PR TITLE
Ensure fresh token when obtaining Supabase client

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,5 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
-import { getToken } from '@clerk/clerk-js'
+import { Clerk } from '@clerk/clerk-js'
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
@@ -24,7 +24,12 @@ if (
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
 
 export const useSupabaseClient = async () => {
-  const token = await getToken({ template: 'supabase' })
+  let token
+  try {
+    token = await Clerk.session?.getToken({ template: 'supabase' })
+  } catch (err) {
+    console.error('Error fetching Clerk token:', err)
+  }
   if (token) {
     try {
       supabase.auth.setAuth(token)


### PR DESCRIPTION
## Summary
- retrieve a Clerk token whenever `useSupabaseClient` is called
- update Supabase auth headers on demand

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687df1a42dfc8333bbbe2fa8256a60b2