### PR TITLE
Add Jenny booking page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import BlogList from './components/blog/BlogList'
 import BlogPost from './components/blog/BlogPost'
 import ProfessionalDirectory from './components/professional-directory/ProfessionalDirectory'
 import Home from './components/pages/Home'
+import JennyBooking from './components/pages/JennyBooking'
 import LandingPage from './components/pages/LandingPage'
 import ProfilePage from './components/pages/ProfilePage'
 import Login from './components/pages/Login'
@@ -49,6 +50,7 @@ const AppRoutes = () => {
       <Route path="/" element={<Home />} />
       <Route path="/login" element={user ? <Navigate to="/dashboard" /> : <Login />} />
       <Route path="/signup" element={<Signup />} />
+      <Route path="/jenny" element={<JennyBooking />} />
       
       {/* Public Routes */}
       <Route path="/blog" element={<BlogList />} />

--- a/src/components/pages/JennyBooking.jsx
+++ b/src/components/pages/JennyBooking.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import MainNav from '../layout/MainNav'
+
+const JennyBooking = () => {
+  return (
+    <div className="min-h-screen bg-anti-flash-white">
+      <MainNav variant="public" />
+      <div className="container mx-auto px-4 py-20 text-center">
+        <h1 className="text-4xl font-bold mb-8">Meet with Jenny</h1>
+        <img
+          src="https://media.publit.io/file/ProsperityWebApp/SebasJenny.jpg"
+          alt="Jenny profile"
+          className="mx-auto w-40 h-40 rounded-full object-cover mb-8 shadow-lg"
+        />
+        <div className="w-full mb-6">
+          <iframe
+            frameBorder="0"
+            width="100%"
+            height="720"
+            src="https://meet.brevo.com/jennyrodmin/borderless?l=zoom-meeting"
+          ></iframe>
+        </div>
+        <p className="mb-4">If the calendar does not load,</p>
+        <a
+          href="https://meet.brevo.com/jennyrodmin"
+          className="btn btn-primary"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Press here
+        </a>
+      </div>
+    </div>
+  )
+}
+
+export default JennyBooking


### PR DESCRIPTION
## Summary
- add a static meeting page at `/jenny`
- wire the route into the app

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687dfa0337848333ac3f0e705fcd0345