### PR TITLE
Add ExamFX PreLicense request page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ import ProfilePage from './components/pages/ProfilePage'
 import Login from './components/pages/Login'
 import Signup from './components/pages/Signup'
 import SebastianBooking from './components/pages/SebastianBooking'
+import ExamfxPreLicense from './components/pages/ExamfxPreLicense'
 import './App.css'
 
 const ProtectedRoute = ({ children, requireAdmin = false }) => {
@@ -58,6 +59,7 @@ const AppRoutes = () => {
       <Route path="/blog/:slug" element={<BlogPost />} />
       <Route path="/find-a-professional" element={<ProfessionalDirectory />} />
       <Route path="/sebastian" element={<SebastianBooking />} />
+      <Route path="/examfx" element={<ExamfxPreLicense />} />
       
       {/* Dashboard Routes */}
       <Route path="/dashboard" element={<ProtectedRoute><DashboardLayout /></ProtectedRoute>}>

--- a/src/components/pages/ExamfxPreLicense.jsx
+++ b/src/components/pages/ExamfxPreLicense.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import MainNav from '../layout/MainNav'
+
+const ExamfxPreLicense = () => {
+  return (
+    <div className="min-h-screen bg-anti-flash-white">
+      <MainNav variant="public" />
+      <div className="container mx-auto px-4 py-20 text-center">
+        <h1 className="text-4xl font-bold mb-8">ExamFX PreLicense Request</h1>
+        <div className="w-full max-w-xl mx-auto">
+          <iframe width="540" height="305" src="https://9d6f3b97.sibforms.com/serve/MUIFAGg3UV4glF-98SDLt88VjFPPM1IzTjhYGjzVBn-m_Re-z2cS8pVkMJbb1ndcItOhHbE5rs92EWA-wHJqZVhDQUt3KgH-qRn4AsCk3oaoasFnUN_jJ-ksQnWwqYPkKVfgV4KK0tftnetp_xj7IHjD2jDy_Rr8BYTlQHlgSMQ__M-ZVL0LWU2Xn5OTI2Oq-swwJtl5Tl8hCmx1" frameBorder="0" scrolling="auto" allowFullScreen style={{ display: 'block', marginLeft: 'auto', marginRight: 'auto', maxWidth: '100%' }}></iframe>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ExamfxPreLicense


### PR DESCRIPTION
## Summary
- add a new `ExamfxPreLicense` page
- route `/examfx` for the new page

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68838b77660483338f18edd1f9912205