### PR TITLE
Rename tables and rebrand app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Prosperity Leaders Platform
+# Prosperity Online Platform
 
-ProsperityOnline is a React-based web application for managing the Prosperity Leaders public website and attracting new leads. The back office equips agents with tools to manage leads, maintain professional profiles, embed booking calendars, deploy landing pages to recruit agents and clients, and track contacts through a simple CRM. Supabase powers the backend, database, and authentication, and Publit.io is used for file hosting. The project relies on Vite for development tooling.
+Prosperity Online is a React-based web application for managing the Prosperity Online public website and attracting new leads. The back office equips agents with tools to manage leads, maintain professional profiles, embed booking calendars, deploy landing pages to recruit agents and clients, and track contacts through a simple CRM. Supabase powers the backend, database, and authentication, and Publit.io is used for file hosting. The project relies on Vite for development tooling.
 
 ## Setup
 

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Prosperity Leaders™ - Faith. Family. Finance.</title>
-    <meta name="description" content="Prosperity Leaders™ empowers families and professionals to grow, protect, and multiply their wealth with clarity and purpose." />
+    <title>Prosperity Online - Faith. Family. Finance.</title>
+    <meta name="description" content="Prosperity Online empowers families and professionals to grow, protect, and multiply their wealth with clarity and purpose." />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/src/components/blog/BlogPost.jsx
+++ b/src/components/blog/BlogPost.jsx
@@ -244,8 +244,8 @@ const BlogPost = () => {
                   </h3>
                   <p className="text-polynesian-blue/70 text-sm">
                     {post.author_type === 'admin' 
-                      ? 'Member of the Prosperity Leaders™ editorial team'
-                      : 'Financial Professional at Prosperity Leaders™'
+                      ? 'Member of the Prosperity Online editorial team'
+                      : 'Financial Professional at Prosperity Online'
                     }
                   </p>
                   <Link

--- a/src/components/cms/ContentManager.jsx
+++ b/src/components/cms/ContentManager.jsx
@@ -31,7 +31,7 @@ const ContentManager = () => {
     try {
       const supabase = await getSupabaseClient()
       const { data, error } = await supabase
-        .from('site_content_12345')
+        .from('site_content_po')
         .select('*')
         .order('section', { ascending: true })
 
@@ -100,7 +100,7 @@ const ContentManager = () => {
       }
       const supabase = await getSupabaseClient()
       const { error } = await supabase
-        .from('site_content_12345')
+        .from('site_content_po')
         .upsert(updates, { onConflict: ['section', 'key'] })
 
       if (error) throw error
@@ -126,7 +126,7 @@ const ContentManager = () => {
       // Add to database
       const supabase = await getSupabaseClient();
       const { error } = await supabase
-        .from('site_content_12345')
+        .from('site_content_po')
         .insert({ section: selectedSection.value, key, value: '' });
 
       if (error && error.code === '23505') {

--- a/src/components/dashboard/Sidebar.jsx
+++ b/src/components/dashboard/Sidebar.jsx
@@ -33,7 +33,7 @@ const Sidebar = () => {
         <Link to="/" className="flex items-center space-x-2">
           <SafeIcon icon={FiBox} className="w-6 h-6 text-picton-blue" />
           <span className="text-lg font-bold text-polynesian-blue">
-            Prosperity Leaders™
+            Prosperity Online
           </span>
         </Link>
       </div>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -21,7 +21,7 @@ const Header = () => {
           <div className="flex items-center">
             <img
               src="https://media.publit.io/file/ProsperityWebApp/Prosperity-Elephant-WIDE-BLUEPNG.png"
-              alt="Prosperity Leaders"
+              alt="Prosperity Online"
               className="h-8 w-auto"
             />
             <span className="ml-2 text-sm text-white/70">Platform</span>

--- a/src/components/layout/MainNav.jsx
+++ b/src/components/layout/MainNav.jsx
@@ -48,7 +48,7 @@ const MainNav = ({ variant = 'public' }) => {
           <Link to="/" className="flex items-center">
             <img
               src="https://media.publit.io/file/ProsperityWebApp/Prosperity-Elephant-WIDE-BLUEPNG.png"
-              alt="Prosperity Leaders"
+              alt="Prosperity Online"
               className="h-8 w-auto"
             />
           </Link>
@@ -101,7 +101,7 @@ const MainNav = ({ variant = 'public' }) => {
               <Link to="/" className="flex items-center space-x-2">
                 <img
                   src="https://media.publit.io/file/ProsperityWebApp/Prosperity-Elephant-WIDE-BLUEPNG.png"
-                  alt="Prosperity Leaders"
+                  alt="Prosperity Online"
                   className="h-8 w-auto"
                 />
                 <span className="ml-2 text-sm text-white/70">Platform</span>
@@ -176,7 +176,7 @@ const MainNav = ({ variant = 'public' }) => {
           <Link to="/" className="flex items-center">
             <img
               src="https://media.publit.io/file/ProsperityWebApp/Prosperity-Elephant-WIDE-BLUEPNG.png"
-              alt="Prosperity Leaders"
+              alt="Prosperity Online"
               className="h-8 w-auto"
             />
           </Link>

--- a/src/components/pages/Home.jsx
+++ b/src/components/pages/Home.jsx
@@ -106,7 +106,7 @@ const Home = () => {
             variants={fadeIn}
           >
             <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6 leading-tight drop-shadow-lg">
-              {content.hero?.headline || 'Welcome to Prosperity Leaders™'}
+              {content.hero?.headline || 'Welcome to Prosperity Online'}
             </h1>
             <p className="text-lg md:text-xl text-white/90 mb-10 max-w-2xl mx-auto drop-shadow">
               {content.hero?.subheadline || 'Empowering families and professionals to grow, protect, and multiply their wealth — with clarity and purpose.'}
@@ -189,7 +189,7 @@ const Home = () => {
         <div className="container mx-auto px-6">
           <div className="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
             <div className="md:col-span-2">
-              <h3 className="text-2xl font-bold mb-4">Prosperity Leaders™</h3>
+              <h3 className="text-2xl font-bold mb-4">Prosperity Online</h3>
               <p className="text-gray-300 mb-4 text-lg italic">
                 {content.footer?.tagline || 'Faith. Family. Finance.'}
               </p>
@@ -233,7 +233,7 @@ const Home = () => {
           </div>
           <div className="border-t border-gray-800 pt-8 flex flex-col md:flex-row justify-between items-center">
             <div className="text-gray-500 text-sm mb-4 md:mb-0">
-              {content.footer?.disclaimer || '© 2023 Prosperity Leaders™. All rights reserved.'}
+              {content.footer?.disclaimer || '© 2023 Prosperity Online. All rights reserved.'}
             </div>
             <div className="flex space-x-4 text-sm">
               <a href="#" className="text-gray-400 hover:text-white transition-colors">English</a>

--- a/src/components/pages/LandingPage.jsx
+++ b/src/components/pages/LandingPage.jsx
@@ -122,7 +122,7 @@ const LandingPage = () => {
                 {user.full_name}
               </span>
               <div className="text-sm text-white/70">
-                Prosperity Leaders™
+                Prosperity Online
               </div>
             </div>
           </div>
@@ -205,7 +205,7 @@ const LandingPage = () => {
           </div>
           
           <div className="border-t border-white/20 mt-8 pt-8 text-center text-sm text-white/60">
-            <p>© 2024 Prosperity Leaders™. All rights reserved.</p>
+            <p>© 2024 Prosperity Online. All rights reserved.</p>
           </div>
         </div>
       </footer>

--- a/src/components/pages/ProfilePage.jsx
+++ b/src/components/pages/ProfilePage.jsx
@@ -99,7 +99,7 @@ const ProfilePage = () => {
               <div className="w-3 h-3 rounded-full bg-picton-blue" />
               <span className="text-sm font-medium text-white/90">Professional Profile</span>
             </div>
-            <div className="text-sm text-white/70">Prosperity Leaders™</div>
+            <div className="text-sm text-white/70">Prosperity Online</div>
           </div>
         </div>
       </motion.header>

--- a/src/components/sections/SectionAbout.jsx
+++ b/src/components/sections/SectionAbout.jsx
@@ -44,7 +44,7 @@ const SectionAbout = ({ content }) => {
             
             <img
               src={content.image_url || "https://media.publit.io/file/ProsperityWebApp/SebasJenny.jpg"}
-              alt="About Prosperity Leaders"
+              alt="About Prosperity Online"
               className="rounded-lg shadow-xl w-full h-auto object-cover z-10 relative"
             />
           </div>
@@ -58,7 +58,7 @@ const SectionAbout = ({ content }) => {
             <div className="h-1 w-24 bg-picton-blue mb-8"></div>
             
             <div className="text-polynesian-blue/80 prose prose-lg mb-8">
-              {renderFormattedContent(content.body || 'Prosperity Leaders™ is a platform dedicated to helping individuals and families achieve financial independence through personalized strategies and expert guidance. Our network of professionals is committed to empowering clients with the knowledge and tools needed to build lasting wealth and security.')}
+              {renderFormattedContent(content.body || 'Prosperity Online is a platform dedicated to helping individuals and families achieve financial independence through personalized strategies and expert guidance. Our network of professionals is committed to empowering clients with the knowledge and tools needed to build lasting wealth and security.')}
             </div>
             
             {content.cta_url && (

--- a/src/components/sections/SectionBlogHighlights.jsx
+++ b/src/components/sections/SectionBlogHighlights.jsx
@@ -134,7 +134,7 @@ const SectionBlogHighlights = () => {
                       <div className="flex items-center space-x-2 text-sm text-polynesian-blue/60 mb-3">
                         <div className="flex items-center space-x-1">
                           <SafeIcon icon={FiUser} className="w-4 h-4" />
-                          <span>{post.author_name || 'Prosperity Leaders'}</span>
+                          <span>{post.author_name || 'Prosperity Online'}</span>
                         </div>
                         <span>•</span>
                         <div className="flex items-center space-x-1">

--- a/src/data/landingPageTemplates.js
+++ b/src/data/landingPageTemplates.js
@@ -231,7 +231,7 @@ export const LANDING_PAGE_TEMPLATES = {
       
       intro: {
         title: "Two Paths to Prosperity",
-        content: "At Prosperity Leaders™, we believe everyone deserves the opportunity to achieve financial freedom. Whether you're seeking professional financial guidance or looking to start a career helping others with their finances, we have the right path for you."
+        content: "At Prosperity Online, we believe everyone deserves the opportunity to achieve financial freedom. Whether you're seeking professional financial guidance or looking to start a career helping others with their finances, we have the right path for you."
       },
       
       splitSection: {

--- a/src/lib/blog.js
+++ b/src/lib/blog.js
@@ -80,7 +80,7 @@ export const getPostBySlug = async (slug) => {
   try {
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('blog_posts_12345')
+      .from('blog_posts_po')
       .select('*')
       .eq('slug', slug)
       .eq('status', 'published')
@@ -100,7 +100,7 @@ export const getAllPosts = async (userId, userRole = 'admin', statusFilter = 'al
     await setUserContext(userId, userRole)
     const supabase = await getSupabaseClient()
     let query = supabase
-      .from('blog_posts_12345')
+      .from('blog_posts_po')
       .select('*')
       .order('updated_at', { ascending: false })
     
@@ -124,7 +124,7 @@ export const getPostsByAuthor = async (authorId, userId, userRole = 'professiona
     await setUserContext(userId, userRole)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('blog_posts_12345')
+      .from('blog_posts_po')
       .select('*')
       .eq('author_id', authorId)
       .order('updated_at', { ascending: false })
@@ -148,7 +148,7 @@ export const createPost = async (postData, userId, userRole = 'professional') =>
     const excerpt = !postData.excerpt ? generateExcerpt(postData.content) : postData.excerpt
     
     const { data, error } = await supabase
-      .from('blog_posts_12345')
+      .from('blog_posts_po')
       .insert([{
         ...postData,
         slug,
@@ -193,7 +193,7 @@ export const updatePost = async (postId, updates, userId, userRole = 'profession
     updateData.updated_at = new Date().toISOString()
     
     const { data, error } = await supabase
-      .from('blog_posts_12345')
+      .from('blog_posts_po')
       .update(updateData)
       .eq('id', postId)
       .select()
@@ -213,7 +213,7 @@ export const deletePost = async (postId, userId, userRole = 'admin') => {
     await setUserContext(userId, userRole)
     const supabase = await getSupabaseClient()
     const { error } = await supabase
-      .from('blog_posts_12345')
+      .from('blog_posts_po')
       .delete()
       .eq('id', postId)
     
@@ -231,7 +231,7 @@ export const approvePost = async (postId, userId, userRole = 'admin') => {
     await setUserContext(userId, userRole)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('blog_posts_12345')
+      .from('blog_posts_po')
       .update({
         status: 'approved',
         updated_at: new Date().toISOString()
@@ -253,7 +253,7 @@ export const rejectPost = async (postId, userId, userRole = 'admin') => {
     await setUserContext(userId, userRole)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('blog_posts_12345')
+      .from('blog_posts_po')
       .update({
         status: 'rejected',
         updated_at: new Date().toISOString()
@@ -275,7 +275,7 @@ export const publishPost = async (postId, userId, userRole = 'admin') => {
     await setUserContext(userId, userRole)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('blog_posts_12345')
+      .from('blog_posts_po')
       .update({
         status: 'published',
         published_at: new Date().toISOString(),
@@ -298,7 +298,7 @@ export const unpublishPost = async (postId, userId, userRole = 'admin') => {
     await setUserContext(userId, userRole)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('blog_posts_12345')
+      .from('blog_posts_po')
       .update({
         status: 'approved',
         published_at: null,
@@ -321,7 +321,7 @@ export const getCategories = async () => {
   try {
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('blog_categories_12345')
+      .from('blog_categories_po')
       .select('*')
       .order('name')
     
@@ -341,7 +341,7 @@ export const createCategory = async (categoryData, userId, userRole = 'admin') =
     const slug = generateSlug(categoryData.name)
     
     const { data, error } = await supabase
-      .from('blog_categories_12345')
+      .from('blog_categories_po')
       .insert([{
         ...categoryData,
         slug,
@@ -363,7 +363,7 @@ export const getLatestPosts = async (limit = 5) => {
   try {
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('blog_posts_12345')
+      .from('blog_posts_po')
       .select('id, title, slug, author_name, published_at')
       .eq('status', 'published')
       .order('published_at', { ascending: false })
@@ -383,7 +383,7 @@ export const searchPosts = async (query, page = 1, limit = 10) => {
     const offset = (page - 1) * limit
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('blog_posts_12345')
+      .from('blog_posts_po')
       .select('*')
       .eq('status', 'published')
       .or(`title.ilike.%${query}%, content.ilike.%${query}%`)

--- a/src/lib/directory.js
+++ b/src/lib/directory.js
@@ -76,7 +76,7 @@ export const getProfessionalByUsername = async (username) => {
   try {
     const supabase = await getSupabaseClient();
     const { data, error } = await supabase
-      .from('users_directory_12345')
+      .from('users_directory_po')
       .select('*')
       .eq('username', username)
       .single();

--- a/src/lib/leads.js
+++ b/src/lib/leads.js
@@ -17,7 +17,7 @@ export const getLeads = async (userId) => {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('leads_12345')
+      .from('leads_po')
       .select('*')
       .order('created_at', { ascending: false })
     
@@ -34,7 +34,7 @@ export const getLead = async (leadId, userId) => {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('leads_12345')
+      .from('leads_po')
       .select('*')
       .eq('id', leadId)
       .single()
@@ -52,7 +52,7 @@ export const createLead = async (leadData) => {
     await setUserContext(leadData.user_id)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('leads_12345')
+      .from('leads_po')
       .insert([{
         ...leadData,
         created_at: new Date().toISOString(),
@@ -74,7 +74,7 @@ export const updateLead = async (leadId, updates, userId) => {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('leads_12345')
+      .from('leads_po')
       .update({
         ...updates,
         updated_at: new Date().toISOString()
@@ -96,7 +96,7 @@ export const deleteLead = async (leadId, userId) => {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
     const { error } = await supabase
-      .from('leads_12345')
+      .from('leads_po')
       .delete()
       .eq('id', leadId)
     
@@ -114,7 +114,7 @@ export const getLeadStats = async (userId) => {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('leads_12345')
+      .from('leads_po')
       .select('status')
     
     if (error) throw error
@@ -140,7 +140,7 @@ export const getLeadNotes = async (leadId, userId) => {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('lead_notes_12345')
+      .from('lead_notes_po')
       .select('*')
       .eq('lead_id', leadId)
       .order('created_at', { ascending: false })
@@ -158,7 +158,7 @@ export const createLeadNote = async (leadId, content, userId) => {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('lead_notes_12345')
+      .from('lead_notes_po')
       .insert([{
         lead_id: leadId,
         user_id: userId,
@@ -182,7 +182,7 @@ export const getLeadTasks = async (leadId, userId) => {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('lead_tasks_12345')
+      .from('lead_tasks_po')
       .select('*')
       .eq('lead_id', leadId)
       .order('due_date', { ascending: true, nullsLast: true })
@@ -200,7 +200,7 @@ export const createLeadTask = async (leadId, taskData, userId) => {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('lead_tasks_12345')
+      .from('lead_tasks_po')
       .insert([{
         lead_id: leadId,
         user_id: userId,
@@ -224,7 +224,7 @@ export const updateLeadTask = async (taskId, updates, userId) => {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('lead_tasks_12345')
+      .from('lead_tasks_po')
       .update({
         ...updates,
         updated_at: new Date().toISOString()

--- a/src/lib/resources.js
+++ b/src/lib/resources.js
@@ -48,7 +48,7 @@ export async function getResources(userId, role = 'professional', filters = {}) 
   try {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
-    let query = supabase.from('resources_12345').select('*')
+    let query = supabase.from('resources_po').select('*')
 
     if (filters.search) query = query.ilike('title', `%${filters.search}%`)
     if (filters.category) query = query.eq('category', filters.category)
@@ -73,7 +73,7 @@ export async function createResource(resourceData, userId) {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('resources_12345')
+      .from('resources_po')
       .insert([
         {
           ...resourceData,
@@ -129,7 +129,7 @@ export async function updateResource(resourceId, updates, userId) {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('resources_12345')
+      .from('resources_po')
       .update({
         ...updates,
         updated_at: new Date().toISOString()
@@ -151,7 +151,7 @@ export async function deleteResource(resourceId, userId) {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
     const { data: resource, error: fetchError } = await supabase
-      .from('resources_12345')
+      .from('resources_po')
       .select('publit_id')
       .eq('id', resourceId)
       .single()
@@ -167,7 +167,7 @@ export async function deleteResource(resourceId, userId) {
     }
 
     const { error } = await supabase
-      .from('resources_12345')
+      .from('resources_po')
       .update({ is_active: false, updated_at: new Date().toISOString() })
       .eq('id', resourceId)
 
@@ -183,7 +183,7 @@ export async function trackResourceAccess(resourceId, userId, actionType) {
   try {
     await setUserContext(userId)
     const supabase = await getSupabaseClient()
-    const { error } = await supabase.from('resource_analytics_12345').insert([
+    const { error } = await supabase.from('resource_analytics_po').insert([
       { resource_id: resourceId, user_id: userId, action_type: actionType }
     ])
     if (error) throw error

--- a/src/lib/reviews.js
+++ b/src/lib/reviews.js
@@ -5,7 +5,7 @@ export const getApprovedReviews = async (professionalUsername) => {
   try {
     const supabase = await getSupabaseClient()
     const { data: reviews, error } = await supabase
-      .from('reviews_12345')
+      .from('reviews_po')
       .select('*')
       .eq('professional_username', professionalUsername)
       .eq('status', 'approved')
@@ -41,7 +41,7 @@ export const getApprovedTestimonials = async (limit = 5) => {
   try {
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('reviews_12345')
+      .from('reviews_po')
       .select('*')
       .eq('status', 'approved')
       .eq('featured', true)
@@ -88,7 +88,7 @@ export const submitReview = async (reviewData) => {
   try {
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('reviews_12345')
+      .from('reviews_po')
       .insert([{
         professional_id: reviewData.professionalId,
         professional_username: reviewData.professionalUsername,
@@ -117,7 +117,7 @@ export const getAllReviews = async (statusFilter = 'all') => {
   try {
     const supabase = await getSupabaseClient()
     let query = supabase
-      .from('reviews_12345')
+      .from('reviews_po')
       .select('*')
       .order('submitted_at', { ascending: false })
     
@@ -141,7 +141,7 @@ export const approveReview = async (reviewId) => {
   try {
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('reviews_12345')
+      .from('reviews_po')
       .update({ 
         status: 'approved', 
         updated_at: new Date().toISOString() 
@@ -162,7 +162,7 @@ export const rejectReview = async (reviewId) => {
   try {
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('reviews_12345')
+      .from('reviews_po')
       .update({ 
         status: 'rejected', 
         updated_at: new Date().toISOString() 
@@ -183,7 +183,7 @@ export const deleteReview = async (reviewId) => {
   try {
     const supabase = await getSupabaseClient()
     const { error } = await supabase
-      .from('reviews_12345')
+      .from('reviews_po')
       .delete()
       .eq('id', reviewId)
     
@@ -201,7 +201,7 @@ export const toggleFeatureReview = async (reviewId, featured) => {
   try {
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('reviews_12345')
+      .from('reviews_po')
       .update({ 
         featured,
         updated_at: new Date().toISOString() 

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -29,7 +29,7 @@ export async function getSiteContent() {
   try {
     const supabase = await getSupabaseClient()
     const { data, error } = await supabase
-      .from('site_content_12345')
+      .from('site_content_po')
       .select('*')
     
     if (error) {
@@ -98,7 +98,7 @@ export const initializeDatabase = async () => {
 export const createUser = async (userData) => {
   const supabase = await getSupabaseClient()
   const { data, error } = await supabase
-    .from('users')
+    .from('users_pf')
     .insert([userData])
     .select()
 
@@ -109,7 +109,7 @@ export const createUser = async (userData) => {
 export const updateUser = async (userId, updates) => {
   const supabase = await getSupabaseClient()
   const { data, error } = await supabase
-    .from('users')
+    .from('users_pf')
     .update(updates)
     .eq('id', userId)
     .select()
@@ -121,7 +121,7 @@ export const updateUser = async (userId, updates) => {
 export const getUserById = async (userId) => {
   const supabase = await getSupabaseClient()
   const { data, error } = await supabase
-    .from('users')
+    .from('users_pf')
     .select('*')
     .eq('id', userId)
     .single()
@@ -133,7 +133,7 @@ export const getUserById = async (userId) => {
 export const getUserByUsername = async (username) => {
   const supabase = await getSupabaseClient()
   const { data, error } = await supabase
-    .from('users')
+    .from('users_pf')
     .select('*')
     .eq('username', username)
     .single()

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ export default {
   theme: {
     extend: {
       colors: {
-        // Prosperity Leaders™ Brand Colors
+        // Prosperity Online Brand Colors
         'picton-blue': '#3AA0FF',
         'polynesian-blue': '#1C1F2A',
         'anti-flash-white': '#F5F7FA',


### PR DESCRIPTION
## Summary
- rename all Supabase tables to `_po` suffix
- switch profile queries to shared `users_pf` table
- rebrand from **Prosperity Leaders** to **Prosperity Online**

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68884697315483338cd0e13a1b02b5e6