### PR TITLE
Improve profile loading error logs

### DIFF
--- a/src/components/pages/ProfilePage.jsx
+++ b/src/components/pages/ProfilePage.jsx
@@ -55,7 +55,20 @@ const ProfilePage = () => {
           setProfile(null)
         }
       } catch (error) {
-        console.error('Error loading profile:', error)
+        // Distinguish between Supabase errors and network-level exceptions
+        if (
+          error &&
+          (error.message || error.details || error.hint || error.code)
+        ) {
+          console.error('Error loading profile:', {
+            message: error.message,
+            details: error.details,
+            hint: error.hint,
+            code: error.code
+          })
+        } else {
+          console.error('Network error loading profile:', error)
+        }
       } finally {
         setIsLoading(false)
       }


### PR DESCRIPTION
## Summary
- log Supabase error details in `ProfilePage`
- distinguish Supabase errors from network exceptions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888ad9a77808333aa3d8f3b5fe9f957