### PR TITLE
Add user checks before fetching pages

### DIFF
--- a/src/components/dashboard/MyLandingPages.jsx
+++ b/src/components/dashboard/MyLandingPages.jsx
@@ -25,7 +25,7 @@ const MyLandingPages = () => {
   const availableTemplates = getAllTemplates()
 
   useEffect(() => {
-    if (user) {
+    if (user && user.id) {
       const loadPages = async () => {
         try {
           const data = await getUserPages(user.id)
@@ -36,6 +36,8 @@ const MyLandingPages = () => {
       }
 
       loadPages()
+    } else if (!user || !user.id) {
+      console.warn('user or user.id missing, skipping getUserPages')
     }
   }, [user])
 

--- a/src/components/dashboard/PagesManager.jsx
+++ b/src/components/dashboard/PagesManager.jsx
@@ -25,7 +25,7 @@ const PagesManager = () => {
   const [creating, setCreating] = useState(false)
 
   useEffect(() => {
-    if (user) {
+    if (user && user.id) {
       const loadPages = async () => {
         try {
           const data = await getUserPages(user.id)
@@ -45,6 +45,8 @@ const PagesManager = () => {
       }
 
       loadPages()
+    } else if (!user || !user.id) {
+      console.warn('user or user.id missing, skipping getUserPages')
     }
   }, [user])
 


### PR DESCRIPTION
## Summary
- ensure `user` and `user.id` exist before calling `getUserPages`
- warn and skip fetching when they are missing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888aeba17b483338437e3e3545bcece