### PR TITLE
Add MultiSelect component and signup fields

### DIFF
--- a/src/components/pages/EnhancedSignup.jsx
+++ b/src/components/pages/EnhancedSignup.jsx
@@ -5,11 +5,22 @@ import { supabase, createUser } from '../../lib/supabase'
 import Input from '../ui/Input'
 import Textarea from '../ui/Textarea'
 import Button from '../ui/Button'
+import MultiSelect from '../ui/MultiSelect'
+import { SERVICE_OPTIONS } from '../../lib/directory'
 
 const EnhancedSignup = () => {
   const navigate = useNavigate()
   const [step, setStep] = useState(1)
   const [submitting, setSubmitting] = useState(false)
+  const [languages, setLanguages] = useState([])
+  const [servicesOffered, setServicesOffered] = useState([])
+
+  const LANGUAGE_OPTIONS = [
+    { value: 'English', label: 'English' },
+    { value: 'Spanish', label: 'Spanish' },
+    { value: 'Mandarin', label: 'Mandarin' },
+    { value: 'French', label: 'French' }
+  ]
   const {
     register,
     handleSubmit,
@@ -64,7 +75,9 @@ const EnhancedSignup = () => {
           city: role === 'advisor' ? data.city : null,
           state: role === 'advisor' ? data.state : null,
           agent_id: role === 'advisor' ? data.agentCode : null,
-          team: role === 'advisor' ? data.team : null
+          team: role === 'advisor' ? data.team : null,
+          languages: role === 'advisor' ? languages.map(l => l.value) : null,
+          services_offered: role === 'advisor' ? servicesOffered.map(s => s.value) : null
         })
       }
       alert('Signup successful! Please check your email to confirm your account.')
@@ -128,6 +141,18 @@ const EnhancedSignup = () => {
           <div className="space-y-4">
             <Input label="Agent Code" error={errors.agentCode?.message} {...register('agentCode')} />
             <Input label="Team" error={errors.team?.message} {...register('team')} />
+            <MultiSelect
+              label="Services Offered"
+              options={SERVICE_OPTIONS}
+              value={servicesOffered}
+              onChange={setServicesOffered}
+            />
+            <MultiSelect
+              label="Languages Spoken"
+              options={LANGUAGE_OPTIONS}
+              value={languages}
+              onChange={setLanguages}
+            />
           </div>
         )}
 

--- a/src/components/ui/MultiSelect.jsx
+++ b/src/components/ui/MultiSelect.jsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import Select from 'react-select'
+
+const MultiSelect = React.forwardRef(({
+  label,
+  options = [],
+  value,
+  onChange,
+  className = '',
+  error,
+  helperText = null,
+  required = false,
+  fullWidth = true,
+  id = null,
+  ...props
+}, ref) => {
+  const selectId = id || `multiselect-${Math.random().toString(36).substring(2,9)}`
+
+  const customStyles = {
+    control: (provided, state) => ({
+      ...provided,
+      minHeight: '2.5rem',
+      boxShadow: state.isFocused ? '0 0 0 2px rgba(6, 182, 212, 0.3)' : undefined,
+      borderColor: error ? '#ef4444' : state.isFocused ? '#38bdf8' : provided.borderColor,
+      '&:hover': { borderColor: state.isFocused ? '#38bdf8' : '#94a3b8' },
+    }),
+    multiValue: provided => ({
+      ...provided,
+      backgroundColor: '#bae6fd',
+    }),
+    multiValueLabel: provided => ({
+      ...provided,
+      color: '#0369a1',
+      fontSize: '0.875rem',
+    }),
+    multiValueRemove: provided => ({
+      ...provided,
+      color: '#0369a1',
+      ':hover': {
+        backgroundColor: '#bfdbfe',
+        color: '#075985',
+      },
+    }),
+    placeholder: provided => ({
+      ...provided,
+      color: '#64748b',
+    }),
+  }
+
+  return (
+    <div className={`space-y-1 ${fullWidth ? 'w-full' : ''}`}>
+      {label && (
+        <label htmlFor={selectId} className="block text-sm font-medium text-polynesian-blue dark:text-white">
+          {label}
+          {required && <span className="text-status-error ml-1">*</span>}
+        </label>
+      )}
+      <Select
+        ref={ref}
+        inputId={selectId}
+        isMulti
+        options={options}
+        value={value}
+        onChange={onChange}
+        className={className}
+        classNamePrefix="multi"
+        styles={customStyles}
+        {...props}
+      />
+      {error && (
+        <p className="text-sm text-status-error">{error}</p>
+      )}
+      {helperText && !error && (
+        <p className="text-sm text-ui-muted dark:text-gray-400">{helperText}</p>
+      )}
+    </div>
+  )
+})
+
+export default MultiSelect


### PR DESCRIPTION
## Summary
- add `MultiSelect` wrapper component for `react-select`
- wire up services offered and languages spoken fields in signup form

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68892e3073e883339efa87445ff954e9