### PR TITLE
Fix signup flow with automatic profile creation

### DIFF
--- a/src/components/pages/EnhancedSignup.jsx
+++ b/src/components/pages/EnhancedSignup.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
-import { supabase, createUser } from '../../lib/supabase'
+import { supabase } from '../../lib/supabase'
 import Input from '../ui/Input'
 import Textarea from '../ui/Textarea'
 import Button from '../ui/Button'
@@ -54,31 +54,30 @@ const EnhancedSignup = () => {
   const onSubmit = async (data) => {
     setSubmitting(true)
     try {
-      const { data: signUpData, error } = await supabase.auth.signUp({
+      const { data: signUpData, error: signUpError } = await supabase.auth.signUp({
         email: data.email,
         password: data.password,
-        options: { data: { role: role } }
+        options: {
+          emailRedirectTo: `${window.location.origin}/login`,
+          data: {
+            role,
+            first_name: data.firstName,
+            last_name: data.lastName,
+            phone: data.phone,
+            agent_id: data.agentCode,
+            team: data.team,
+            username: role === 'advisor' ? data.username : null,
+            title: role === 'advisor' ? data.title : null,
+            city: role === 'advisor' ? data.city : null,
+            state: role === 'advisor' ? data.state : null,
+            languages: role === 'advisor' ? languages.map(l => l.value) : null,
+            services_offered: role === 'advisor' ? servicesOffered.map(s => s.value) : null
+          }
+        }
       })
-      if (error) throw error
-      const user = signUpData.user
-      if (user) {
-        await createUser({
-          id: user.id,
-          role,
-          first_name: data.firstName,
-          last_name: data.lastName,
-          full_name: `${data.firstName} ${data.lastName}`,
-          email: data.email,
-          phone: data.phone || null,
-          username: role === 'advisor' ? data.username : null,
-          title: role === 'advisor' ? data.title : null,
-          city: role === 'advisor' ? data.city : null,
-          state: role === 'advisor' ? data.state : null,
-          agent_id: role === 'advisor' ? data.agentCode : null,
-          team: role === 'advisor' ? data.team : null,
-          languages: role === 'advisor' ? languages.map(l => l.value) : null,
-          services_offered: role === 'advisor' ? servicesOffered.map(s => s.value) : null
-        })
+      if (signUpError) throw signUpError
+      if (signUpData.user) {
+        // Profile will be created by AuthProvider on session establishment
       }
       alert('Signup successful! Please check your email to confirm your account.')
       navigate('/login')

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -15,12 +15,113 @@ export const AuthProvider = ({ children }) => {
   const [userData, setUserData] = useState(null)
   const [loading, setLoading] = useState(true)
 
+  const fetchProfile = async (session) => {
+    const { user } = session
+    if (!user) return
+
+    try {
+      let { data: profile } = await supabase
+        .from('users_pf')
+        .select('*')
+        .eq('id', user.id)
+        .single()
+
+      if (!profile) {
+        ;({ data: profile } = await supabase
+          .from('users_pf')
+          .select('*')
+          .eq('email', user.email)
+          .single())
+      }
+
+      if (!profile) {
+        const meta = user.user_metadata || {}
+        const newProfile = {
+          id: user.id,
+          email: user.email,
+          role: meta.role || null,
+          first_name: meta.first_name || null,
+          last_name: meta.last_name || null,
+          full_name:
+            meta.full_name ||
+            [meta.first_name, meta.last_name].filter(Boolean).join(' ') ||
+            null,
+          phone: meta.phone || null,
+          agent_id: meta.agent_id || null,
+          team: meta.team || null,
+          username: meta.username || null,
+          title: meta.title || null,
+          city: meta.city || null,
+          state: meta.state || null,
+          languages: meta.languages || null,
+          services_offered: meta.services_offered || null
+        }
+
+        const { data: inserted, error: insertError } = await supabase
+          .from('users_pf')
+          .insert(newProfile)
+          .select()
+          .single()
+
+        if (insertError) {
+          if (insertError.code === '23505') {
+            const { data: updated, error: updateError } = await supabase
+              .from('users_pf')
+              .update(newProfile)
+              .eq('id', user.id)
+              .select()
+              .single()
+            if (updateError) throw updateError
+            profile = updated
+          } else {
+            throw insertError
+          }
+        } else {
+          profile = inserted
+        }
+      }
+
+      if (profile && profile.role === 'advisor') {
+        const dirData = {
+          user_id: profile.id,
+          username: profile.username,
+          full_name: profile.full_name,
+          title: profile.title,
+          city: profile.city,
+          state: profile.state,
+          languages: profile.languages,
+          services_offered: profile.services_offered,
+          profile_photo_url: profile.profile_photo_url || null,
+          has_calendly: !!profile.calendly_link
+        }
+
+        const { error: insertDirError } = await supabase
+          .from('users_directory_po')
+          .insert(dirData)
+
+        if (insertDirError && insertDirError.code === '23505') {
+          await supabase
+            .from('users_directory_po')
+            .update(dirData)
+            .eq('user_id', profile.id)
+        }
+      }
+
+      setUserData({ ...user, ...profile })
+    } catch (error) {
+      console.error('Error fetching profile:', error)
+      setUserData(user)
+    }
+  }
+
   useEffect(() => {
     const init = async () => {
       const {
-        data: { user }
-      } = await supabase.auth.getUser()
-      setUserData(user)
+        data: { session }
+      } = await supabase.auth.getSession()
+      if (session) {
+        await fetchProfile(session)
+      }
       setLoading(false)
     }
     init()
@@ -28,7 +129,12 @@ export const AuthProvider = ({ children }) => {
     const {
       data: { subscription }
     } = supabase.auth.onAuthStateChange((_event, session) => {
-      setUserData(session?.user ?? null)
+      if (session) {
+        setLoading(true)
+        fetchProfile(session).finally(() => setLoading(false))
+      } else {
+        setUserData(null)
+      }
     })
 
     return () => {


### PR DESCRIPTION
## Summary
- simplify `EnhancedSignup` to only call `supabase.auth.signUp`
- extend `AuthProvider` to create or update `users_pf` and directory entry upon auth session

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68893c7f4df88333b4873653e1fe39ab