### PR TITLE
Normalize review rating handling

### DIFF
--- a/src/components/reviews/ReviewsList.jsx
+++ b/src/components/reviews/ReviewsList.jsx
@@ -6,6 +6,8 @@ import SafeIcon from '../../common/SafeIcon'
 const { FiStar } = FiIcons
 
 const ReviewsList = ({ reviews, averageRating = 0, reviewCount = 0, loading = false }) => {
+  const rating = Number(averageRating)
+
   if (loading) {
     return (
       <div className="flex justify-center items-center h-40">
@@ -33,7 +35,7 @@ const ReviewsList = ({ reviews, averageRating = 0, reviewCount = 0, loading = fa
                 key={i}
                 icon={FiStar}
                 className={`w-5 h-5 ${
-                  i < Math.floor(averageRating)
+                  i < Math.floor(rating)
                     ? 'text-yellow-400 fill-yellow-400'
                     : 'text-gray-300'
                 }`}
@@ -41,7 +43,7 @@ const ReviewsList = ({ reviews, averageRating = 0, reviewCount = 0, loading = fa
             ))}
           </div>
           <span className="ml-2 text-lg font-medium text-polynesian-blue">
-            {averageRating.toFixed(1)}
+            {rating.toFixed(1)}
           </span>
         </div>
         <span className="text-sm text-polynesian-blue/60">

--- a/src/components/reviews/ReviewsStats.jsx
+++ b/src/components/reviews/ReviewsStats.jsx
@@ -5,7 +5,8 @@ import SafeIcon from '../../common/SafeIcon'
 const { FiStar } = FiIcons
 
 const ReviewsStats = ({ averageRating = 0, reviewCount = 0, className = '' }) => {
-  if (!averageRating || !reviewCount) {
+  const rating = Number(averageRating)
+  if (!Number.isFinite(rating) || !reviewCount) {
     return null
   }
 
@@ -17,7 +18,7 @@ const ReviewsStats = ({ averageRating = 0, reviewCount = 0, className = '' }) =>
             key={i}
             icon={FiStar}
             className={`w-4 h-4 ${
-              i < Math.floor(averageRating)
+              i < Math.floor(rating)
                 ? 'text-yellow-400 fill-yellow-400'
                 : 'text-gray-300'
             }`}
@@ -25,7 +26,7 @@ const ReviewsStats = ({ averageRating = 0, reviewCount = 0, className = '' }) =>
         ))}
       </div>
       <span className="text-sm font-medium text-polynesian-blue">
-        {averageRating.toFixed(1)}
+        {rating.toFixed(1)}
       </span>
       <span className="text-sm text-polynesian-blue/60">
         ({reviewCount})

--- a/src/lib/reviews.js
+++ b/src/lib/reviews.js
@@ -16,19 +16,22 @@ export const getApprovedReviews = async (professionalUsername) => {
     // Get average rating using the function we created
     const { data: ratingData, error: ratingError } = await supabase
       .rpc('get_professional_rating', { p_username: professionalUsername })
-    
+
     if (ratingError) throw ratingError
 
     // Get review count using the function we created
     const { data: countData, error: countError } = await supabase
       .rpc('count_professional_reviews', { p_username: professionalUsername })
-    
+
     if (countError) throw countError
+
+    const rating = parseFloat(ratingData)
+    const count = parseInt(countData, 10)
 
     return {
       reviews: reviews || [],
-      averageRating: ratingData || 0,
-      reviewCount: countData || 0
+      averageRating: rating || 0,
+      reviewCount: count || 0
     }
   } catch (error) {
     console.error('Error fetching reviews:', error)
@@ -62,20 +65,23 @@ export const getProfessionalRating = async (professionalUsername) => {
   try {
     // Get average rating
     const supabase = await getSupabaseClient()
-    const { data: averageRating, error: ratingError } = await supabase
+    const { data: ratingData, error: ratingError } = await supabase
       .rpc('get_professional_rating', { p_username: professionalUsername })
-    
+
     if (ratingError) throw ratingError
 
     // Get review count
-    const { data: reviewCount, error: countError } = await supabase
+    const { data: countData, error: countError } = await supabase
       .rpc('count_professional_reviews', { p_username: professionalUsername })
-    
+
     if (countError) throw countError
 
+    const rating = parseFloat(ratingData)
+    const count = parseInt(countData, 10)
+
     return {
-      averageRating: averageRating || 0,
-      reviewCount: reviewCount || 0
+      averageRating: rating || 0,
+      reviewCount: count || 0
     }
   } catch (error) {
     console.error('Error fetching professional rating:', error)


### PR DESCRIPTION
## Summary
- Parse Supabase RPC review stats to numbers
- Normalize review ratings before rendering and use consistent formatting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3dda03be88333bfca3f30e8f8be1c