### PR TITLE
fix: ensure modal overlay uses proper z-index

### DIFF
--- a/src/components/ui/Modal.jsx
+++ b/src/components/ui/Modal.jsx
@@ -86,7 +86,7 @@ const Modal = ({
               animate={{ opacity: 1, scale: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.95, y: 10 }}
               transition={{ type: "spring", damping: 20, stiffness: 300 }}
-              className={`z-[10000] inline-block align-bottom bg-white dark:bg-polynesian-blue rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full ${sizes[size]}`}
+              className={`relative z-[10000] inline-block align-bottom bg-white dark:bg-polynesian-blue rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full ${sizes[size]}`}
             >
               {/* Header */}
               {title && (


### PR DESCRIPTION
## Summary
- ensure modal's z-index is applied by giving content wrapper positioning

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a63d4a1e088333b33ebd2348a9c0cb