### PR TITLE
Add Agent resources page with key links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import Login from './components/pages/Login'
 import EnhancedSignup from './components/pages/EnhancedSignup'
 import SebastianBooking from './components/pages/SebastianBooking'
 import ExamfxPreLicense from './components/pages/ExamfxPreLicense'
+import AgentLinks from './components/pages/AgentLinks'
 import './App.css'
 
 const ProtectedRoute = ({ children, requireAdmin = false }) => {
@@ -60,6 +61,7 @@ const AppRoutes = () => {
       <Route path="/find-a-professional" element={<ProfessionalDirectory />} />
       <Route path="/sebastian" element={<SebastianBooking />} />
       <Route path="/examfx" element={<ExamfxPreLicense />} />
+      <Route path="/agents" element={<AgentLinks />} />
       
       {/* Dashboard Routes */}
       <Route path="/dashboard" element={<ProtectedRoute><DashboardLayout /></ProtectedRoute>}>

--- a/src/components/layout/MainNav.jsx
+++ b/src/components/layout/MainNav.jsx
@@ -190,6 +190,7 @@ const MainNav = ({ variant = 'public' }) => {
             <Link to="/services" className="text-white hover:text-[#3AA0FF] transition-colors">Services</Link>
             <Link to="/find-a-professional" className="text-white hover:text-[#3AA0FF] transition-colors">Find a Professional</Link>
             <Link to="/blog" className="text-white hover:text-[#3AA0FF] transition-colors">Blog</Link>
+            <Link to="/agents" className="text-white hover:text-[#3AA0FF] transition-colors">Agents</Link>
             <Link to="/contact" className="text-white hover:text-[#3AA0FF] transition-colors">Contact</Link>
             
             {/* Theme Toggle */}

--- a/src/components/pages/AgentLinks.jsx
+++ b/src/components/pages/AgentLinks.jsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import MainNav from '../layout/MainNav'
+
+const agentLinks = [
+  { title: 'GFI Rocket Retirement Report: prosperity', url: 'https://shor.by/UHHT' },
+  { title: 'SureLC™: GFI Agents Appointment & Contracting', url: 'https://shor.by/UmwL' },
+  { title: 'Ethos Agent Dashboard', url: 'https://shor.by/I8XZ' },
+  { title: 'WinFlex Web - Register & Login: All Illustrations', url: 'https://shor.by/4GhQ' },
+  { title: 'American National Life (Anico) – Available in NY', url: 'https://shor.by/aYbi' },
+  { title: 'Mutual of Omaha for GFI – Available in NY', url: 'https://shor.by/lZbe' },
+  { title: 'More Questions? - ¿Mas Preguntas? (Clave: prosperity)', url: 'https://shor.by/Vdzp' },
+  { title: 'Calculator to Compare 401K Retirement Fees', url: 'https://shor.by/XP9c' },
+  { title: 'Corbridge QOL Rapid Rater: Life Quotes & Illustrations', url: 'https://shor.by/GeJ1' },
+  { title: 'Corebridge Financial Connext Site (Register to submit igo)', url: 'https://shor.by/8qoB' },
+  { title: 'SuccessCE: AML, Licensed Agent Trainings and Continuing Education', url: 'https://shor.by/7rPU' },
+  { title: 'SILAC Microsite | Annuities', url: 'https://shor.by/nFim' }
+]
+
+const AgentLinks = () => {
+  return (
+    <div className="min-h-screen bg-anti-flash-white">
+      <MainNav variant="public" />
+      <div className="container mx-auto px-6 pt-24 pb-12">
+        <h1 className="text-3xl font-bold text-center mb-8">Agent Resources</h1>
+        <div className="max-w-2xl mx-auto space-y-4">
+          {agentLinks.map(link => (
+            <a
+              key={link.url}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block w-full bg-picton-blue text-white py-3 px-4 rounded-lg text-center hover:bg-picton-blue/90"
+            >
+              {link.title}
+            </a>
+          ))}
+          <a
+            href="https://shor.by/prosper"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block w-full bg-accent-teal text-white py-3 px-4 rounded-lg text-center hover:bg-accent-teal/90"
+          >
+            shor.by/prosper
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default AgentLinks
+


### PR DESCRIPTION
## Summary
- add Agent Resources page listing links from shor.by/prosper
- expose page at `/agents` and link from main navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a90a36abb883338a911b8a7f930442