### PR TITLE
Add slug-based routes for landing pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -62,7 +62,8 @@ const AppRoutes = () => {
       <Route path="/sebastian" element={<SebastianBooking />} />
       <Route path="/examfx" element={<ExamfxPreLicense />} />
       <Route path="/agents" element={<AgentLinks />} />
-      
+      <Route path="/pages/:slug" element={<LandingPage />} />
+
       {/* Dashboard Routes */}
       <Route path="/dashboard" element={<ProtectedRoute><DashboardLayout /></ProtectedRoute>}>
         <Route index element={<Dashboard />} />

--- a/src/components/dashboard/MyLandingPages.jsx
+++ b/src/components/dashboard/MyLandingPages.jsx
@@ -100,7 +100,7 @@ const MyLandingPages = () => {
   }
 
   const generatePageUrl = (customUsername) => {
-    return `https://prosperityleaders.net/${customUsername}`
+    return `https://prosperityleaders.net/pages/${customUsername}`
   }
 
   return (

--- a/src/components/dashboard/PagesManager.jsx
+++ b/src/components/dashboard/PagesManager.jsx
@@ -83,7 +83,7 @@ const PagesManager = () => {
   }
 
   const generatePageUrl = (customUsername) => {
-    return `https://prosperityleaders.net/${customUsername}`
+    return `https://prosperityleaders.net/pages/${customUsername}`
   }
 
   return (

--- a/src/components/pages/LandingPage.jsx
+++ b/src/components/pages/LandingPage.jsx
@@ -11,7 +11,7 @@ import SafeIcon from '../../common/SafeIcon'
 const { FiArrowLeft } = FiIcons
 
 const LandingPage = () => {
-  const { username, custom } = useParams()
+  const { slug, username, custom } = useParams()
   const navigate = useNavigate()
   const [isLoading, setIsLoading] = useState(true)
   const [pageData, setPageData] = useState(null)
@@ -22,8 +22,9 @@ const LandingPage = () => {
       try {
         setIsLoading(true)
 
-        // Build the full custom username path
-        const fullPath = custom ? `${username}-${custom}` : username
+        // Build the full custom username path. Support both legacy username/custom
+        // routes and the new /pages/:slug format.
+        const fullPath = slug || (custom ? `${username}-${custom}` : username)
 
         // Fetch page from Supabase
         const landingPage = await getPageByCustomUsername(fullPath)
@@ -53,7 +54,7 @@ const LandingPage = () => {
     }
 
     loadPage()
-  }, [username, custom])
+  }, [slug, username, custom])
 
   const handleFormSubmit = async (formData) => {
     // In production, this would submit to your backend


### PR DESCRIPTION
## Summary
- Add new `/pages/:slug` route to serve landing pages
- Generate landing page URLs with `/pages/` prefix in dashboard managers
- Support slug-based URLs in `LandingPage` component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc95d142908333ac9fa8c563028248