### PR TITLE
feat: toast navigation after creating landing pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react-icons": "^5.4.0",
         "react-intersection-observer": "^9.5.3",
         "react-router-dom": "^7.1.0",
-        "react-select": "^5.7.4"
+        "react-select": "^5.7.4",
+        "sonner": "^1.7.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -3771,6 +3772,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
+      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-icons": "^5.4.0",
     "react-intersection-observer": "^9.5.3",
     "react-router-dom": "^7.1.0",
-    "react-select": "^5.7.4"
+    "react-select": "^5.7.4",
+    "sonner": "^1.7.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/components/dashboard/MyLandingPages.jsx
+++ b/src/components/dashboard/MyLandingPages.jsx
@@ -9,6 +9,8 @@ import Modal from '../ui/Modal'
 import Input from '../ui/Input'
 import * as FiIcons from 'react-icons/fi'
 import SafeIcon from '../../common/SafeIcon'
+import { useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
 
 const { FiPlus, FiTrash2, FiEdit3, FiExternalLink, FiGlobe, FiInfo } = FiIcons
 
@@ -23,6 +25,7 @@ const MyLandingPages = () => {
   })
   const [creating, setCreating] = useState(false)
   const availableTemplates = getAllTemplates()
+  const navigate = useNavigate()
 
   useEffect(() => {
     if (user && user.id) {
@@ -73,12 +76,17 @@ const MyLandingPages = () => {
 
       const created = await createPage(pageData)
       setPages(prev => [...prev, created])
-      setShowCreateModal(false)
-      setNewPage({
-        template_type: 'recruiting',
-        custom_username: '',
-        title: ''
+      toast.success('Landing page created', {
+        action: {
+          label: 'View Page',
+          onClick: () => window.open(generatePageUrl(created.custom_username), '_blank')
+        },
+        cancel: {
+          label: 'Continue Editing',
+          onClick: () => navigate(`/dashboard/landing-pages/${created.id}`)
+        }
       })
+      navigate(`/dashboard/landing-pages/${created.id}`)
     } catch (error) {
       console.error('Error creating page:', error)
       alert('Failed to create page')
@@ -111,7 +119,14 @@ const MyLandingPages = () => {
           <h2 className="text-xl font-semibold text-polynesian-blue">My Landing Pages</h2>
         </div>
         <Button
-          onClick={() => setShowCreateModal(true)}
+          onClick={() => {
+            setNewPage({
+              template_type: 'recruiting',
+              custom_username: '',
+              title: ''
+            })
+            setShowCreateModal(true)
+          }}
           className="flex items-center space-x-2"
         >
           <SafeIcon icon={FiPlus} className="w-4 h-4" />

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,11 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
+import { Toaster } from 'sonner'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />
+    <Toaster richColors />
   </StrictMode>
 )


### PR DESCRIPTION
## Summary
- navigate to the new landing page's editor after creation
- show success toast with view and edit actions
- integrate Sonner toaster for notifications

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc9b4b9f008333af89c882365db9d4