### PR TITLE
feat: add landing page editor with autosave

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Dashboard from './components/pages/Dashboard'
 import ContentManager from './components/cms/ContentManager'
 import ProfessionalProfile from './components/dashboard/ProfessionalProfile'
 import MyLandingPages from './components/dashboard/MyLandingPages'
+import LandingPageEditor from './components/landingPages/LandingPageEditor'
 import ResourcesCenter from './components/resources/ResourcesCenter'
 import LeadsLayout from './components/leads/LeadsLayout'
 import LeadsDashboard from './components/leads/LeadsDashboard'
@@ -69,6 +70,7 @@ const AppRoutes = () => {
         <Route index element={<Dashboard />} />
         <Route path="professional-profile" element={<ProfessionalProfile />} />
         <Route path="landing-pages" element={<MyLandingPages />} />
+        <Route path="landing-pages/:id/edit" element={<LandingPageEditor />} />
         <Route path="resources" element={<ResourcesCenter />} />
         <Route path="blog-submission" element={<AgentBlogSubmission />} />
         

--- a/src/components/dashboard/MyLandingPages.jsx
+++ b/src/components/dashboard/MyLandingPages.jsx
@@ -83,10 +83,10 @@ const MyLandingPages = () => {
         },
         cancel: {
           label: 'Continue Editing',
-          onClick: () => navigate(`/dashboard/landing-pages/${created.id}`)
+          onClick: () => navigate(`/dashboard/landing-pages/${created.id}/edit`)
         }
       })
-      navigate(`/dashboard/landing-pages/${created.id}`)
+      navigate(`/dashboard/landing-pages/${created.id}/edit`)
     } catch (error) {
       console.error('Error creating page:', error)
       alert('Failed to create page')
@@ -200,6 +200,7 @@ const MyLandingPages = () => {
                       variant="outline"
                       size="sm"
                       className="flex items-center space-x-1"
+                      onClick={() => navigate(`/dashboard/landing-pages/${page.id}/edit`)}
                     >
                       <SafeIcon icon={FiEdit3} className="w-4 h-4" />
                       <span>Edit</span>

--- a/src/components/landingPages/LandingPageEditor.jsx
+++ b/src/components/landingPages/LandingPageEditor.jsx
@@ -1,0 +1,111 @@
+import React, { useState, useEffect, useRef } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { getPageById, updatePage } from '../../lib/supabase'
+import Card from '../ui/Card'
+import Input from '../ui/Input'
+import Textarea from '../ui/Textarea'
+import Button from '../ui/Button'
+
+const LandingPageEditor = () => {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const [form, setForm] = useState({ title: '', content: '' })
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [unsaved, setUnsaved] = useState(false)
+  const saveTimeout = useRef(null)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const page = await getPageById(id)
+        setForm({ title: page.title || '', content: page.content || '' })
+      } catch (err) {
+        console.error('Error loading page:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    load()
+  }, [id])
+
+  useEffect(() => {
+    const handleBeforeUnload = (e) => {
+      if (unsaved) {
+        e.preventDefault()
+        e.returnValue = ''
+      }
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [unsaved])
+
+  const save = async (updates) => {
+    setSaving(true)
+    try {
+      const updated = await updatePage(id, updates)
+      setForm(prev => ({ ...prev, ...updated }))
+      setUnsaved(false)
+    } catch (err) {
+      console.error('Error saving page:', err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const scheduleSave = (updates) => {
+    setUnsaved(true)
+    if (saveTimeout.current) clearTimeout(saveTimeout.current)
+    saveTimeout.current = setTimeout(() => save(updates), 1000)
+  }
+
+  const handleChange = (field) => (e) => {
+    const value = e.target.value
+    setForm(prev => ({ ...prev, [field]: value }))
+    scheduleSave({ [field]: value })
+  }
+
+  const handleBack = () => {
+    if (!unsaved || window.confirm('You have unsaved changes. Leave anyway?')) {
+      navigate('/dashboard/landing-pages')
+    }
+  }
+
+  const handleManualSave = () => {
+    if (saveTimeout.current) clearTimeout(saveTimeout.current)
+    save(form)
+  }
+
+  if (loading) {
+    return <div className="p-6">Loading...</div>
+  }
+
+  return (
+    <Card className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-polynesian-blue">Edit Landing Page</h2>
+        <div className="text-sm text-polynesian-blue/70">
+          {saving ? 'Saving...' : unsaved ? 'Unsaved changes' : 'All changes saved'}
+        </div>
+      </div>
+      <Input
+        label="Title"
+        value={form.title}
+        onChange={handleChange('title')}
+      />
+      <Textarea
+        label="Content"
+        rows={10}
+        value={form.content}
+        onChange={handleChange('content')}
+      />
+      <div className="flex justify-end space-x-3">
+        <Button variant="outline" onClick={handleBack}>Back</Button>
+        <Button onClick={handleManualSave} disabled={saving || !unsaved}>Save</Button>
+      </div>
+    </Card>
+  )
+}
+
+export default LandingPageEditor

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -223,3 +223,28 @@ export const deletePage = async (pageId) => {
 
   if (error) throw error
 }
+
+export const getPageById = async (pageId) => {
+  const supabase = await getSupabaseClient()
+  const { data, error } = await supabase
+    .from('pages_po')
+    .select('*')
+    .eq('id', pageId)
+    .single()
+
+  if (error) throw error
+  return data
+}
+
+export const updatePage = async (pageId, updates) => {
+  const supabase = await getSupabaseClient()
+  const { data, error } = await supabase
+    .from('pages_po')
+    .update(updates)
+    .eq('id', pageId)
+    .select()
+    .single()
+
+  if (error) throw error
+  return data
+}


### PR DESCRIPTION
## Summary
- add Supabase helpers for page fetch and update
- add landing page editor with auto-save and unsaved change warnings
- wire dashboard routing and links to new editor

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bca6b34bd4833389d4c1958c1f4d4b