### PR TITLE
Refactor public routes for landing and profile pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -63,7 +63,6 @@ const AppRoutes = () => {
       <Route path="/sebastian" element={<SebastianBooking />} />
       <Route path="/examfx" element={<ExamfxPreLicense />} />
       <Route path="/agents" element={<AgentLinks />} />
-      <Route path="/pages/:slug" element={<LandingPage />} />
 
       {/* Dashboard Routes */}
       <Route path="/dashboard" element={<ProtectedRoute><DashboardLayout /></ProtectedRoute>}>
@@ -87,8 +86,8 @@ const AppRoutes = () => {
       </Route>
       
       {/* Public Profile & Landing Pages Routes */}
-      <Route path="/:username" element={<ProfilePage />} />
-      <Route path="/:username/:custom" element={<LandingPage />} />
+      <Route path="/profile/:username" element={<ProfilePage />} />
+      <Route path="/:custom_username" element={<LandingPage />} />
     </Routes>
   )
 }

--- a/src/components/dashboard/MyLandingPages.jsx
+++ b/src/components/dashboard/MyLandingPages.jsx
@@ -108,7 +108,7 @@ const MyLandingPages = () => {
   }
 
   const generatePageUrl = (customUsername) => {
-    return `https://prosperityleaders.net/pages/${customUsername}`
+    return `https://prosperityleaders.net/${customUsername}`
   }
 
   return (
@@ -141,7 +141,7 @@ const MyLandingPages = () => {
         </div>
         <p>
           Your professional profile is available at{' '}
-          <span className="font-semibold">prosperityleaders.net/{user?.username}</span>.
+          <span className="font-semibold">prosperityleaders.net/profile/{user?.username}</span>.
           Landing pages are additional marketing pages with specific themes you can create below.
         </p>
       </div>

--- a/src/components/dashboard/PagesManager.jsx
+++ b/src/components/dashboard/PagesManager.jsx
@@ -83,7 +83,7 @@ const PagesManager = () => {
   }
 
   const generatePageUrl = (customUsername) => {
-    return `https://prosperityleaders.net/pages/${customUsername}`
+    return `https://prosperityleaders.net/${customUsername}`
   }
 
   return (

--- a/src/components/dashboard/ProfessionalProfile.jsx
+++ b/src/components/dashboard/ProfessionalProfile.jsx
@@ -183,7 +183,7 @@ const ProfessionalProfile = () => {
     setShowAddTestimonialModal(false)
   }
 
-  const profileUrl = `https://prosperityleaders.net/${user?.username}`
+  const profileUrl = `https://prosperityleaders.net/profile/${user?.username}`
 
   if (!profile) {
     return (
@@ -236,7 +236,7 @@ const ProfessionalProfile = () => {
             <span>Your Professional Profile</span>
           </div>
           <p>
-            This is your primary public profile, always available at <span className="font-semibold">prosperityleaders.net/{user?.username}</span>. It represents you in the professional directory and is linked from all your landing pages.
+            This is your primary public profile, always available at <span className="font-semibold">prosperityleaders.net/profile/{user?.username}</span>. It represents you in the professional directory and is linked from all your landing pages.
           </p>
         </div>
 

--- a/src/components/landingPages/LandingPageTemplate.jsx
+++ b/src/components/landingPages/LandingPageTemplate.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import * as FiIcons from 'react-icons/fi'
 import SafeIcon from '../../common/SafeIcon'
@@ -11,6 +11,22 @@ const LandingPageTemplate = ({ template = {}, content = {}, professional = {}, o
   const [formData, setFormData] = useState({})
   const [submitting, setSubmitting] = useState(false)
   const [submitted, setSubmitted] = useState(false)
+
+  useEffect(() => {
+    const seo = content?.seo || {}
+    if (seo.title) {
+      document.title = seo.title
+    }
+    if (seo.description) {
+      let tag = document.querySelector('meta[name="description"]')
+      if (!tag) {
+        tag = document.createElement('meta')
+        tag.setAttribute('name', 'description')
+        document.head.appendChild(tag)
+      }
+      tag.setAttribute('content', seo.description)
+    }
+  }, [content])
 
   const handleFormChange = (field, value) => {
     setFormData(prev => ({
@@ -78,6 +94,43 @@ const LandingPageTemplate = ({ template = {}, content = {}, professional = {}, o
       default:
         return <Input {...commonProps} type="text" />
     }
+  }
+
+  // Convert simple JSONB sections into responsive HTML
+  const renderSections = () => {
+    return content.sections.map((section, index) => {
+      switch (section.type) {
+        case 'hero':
+          return (
+            <section key={index} className="py-16 px-4 text-center">
+              {section.image && (
+                <img src={section.image} alt="" className="mx-auto mb-6 max-w-full h-auto" />
+              )}
+              {section.title && (
+                <h1 className="text-4xl md:text-5xl font-bold text-polynesian-blue mb-4">{section.title}</h1>
+              )}
+              {section.subtitle && (
+                <p className="text-lg md:text-xl text-polynesian-blue/70 mb-6">{section.subtitle}</p>
+              )}
+            </section>
+          )
+        default:
+          return (
+            <section key={index} className="py-12 px-4 text-center">
+              {section.title && (
+                <h2 className="text-2xl md:text-3xl font-bold text-polynesian-blue mb-4">{section.title}</h2>
+              )}
+              {section.body && (
+                <p className="max-w-3xl mx-auto text-polynesian-blue/70">{section.body}</p>
+              )}
+            </section>
+          )
+      }
+    })
+  }
+
+  if (Array.isArray(content.sections)) {
+    return <div>{renderSections()}</div>
   }
 
   // Dynamic block-based rendering for builder previews

--- a/src/components/layout/MainNav.jsx
+++ b/src/components/layout/MainNav.jsx
@@ -141,7 +141,7 @@ const MainNav = ({ variant = 'public' }) => {
                       onClick={() => setUserMenuOpen(false)}
                     >
                       <Link
-                        to="/profile"
+                        to={`/profile/${user.username}`}
                         className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
                       >
                         <SafeIcon icon={FiUser} className="inline-block mr-2 w-4 h-4" />
@@ -227,7 +227,7 @@ const MainNav = ({ variant = 'public' }) => {
                       Dashboard
                     </Link>
                     <Link
-                      to="/profile"
+                      to={`/profile/${user.username}`}
                       className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
                     >
                       Profile
@@ -346,7 +346,7 @@ const MainNav = ({ variant = 'public' }) => {
                       Dashboard
                     </Link>
                     <Link
-                      to="/profile"
+                      to={`/profile/${user.username}`}
                       className="text-white hover:text-[#3AA0FF] transition-colors py-2 pl-10"
                       onClick={() => setMobileMenuOpen(false)}
                     >

--- a/src/components/pages/LandingPage.jsx
+++ b/src/components/pages/LandingPage.jsx
@@ -6,15 +6,17 @@ import { getPageByCustomUsername } from '../../lib/supabase'
 import LandingPageTemplate from '../landingPages/LandingPageTemplate'
 import * as FiIcons from 'react-icons/fi'
 import SafeIcon from '../../common/SafeIcon'
+import NotFound from './NotFound'
 
 const { FiArrowLeft } = FiIcons
 
 const LandingPage = () => {
-  const { slug } = useParams()
+  const { custom_username, username } = useParams()
   const navigate = useNavigate()
   const [isLoading, setIsLoading] = useState(true)
   const [pageData, setPageData] = useState(null)
   const [error, setError] = useState(null)
+  const [notFound, setNotFound] = useState(false)
 
   useEffect(() => {
     const loadPage = async () => {
@@ -22,8 +24,8 @@ const LandingPage = () => {
         setIsLoading(true)
         setError(null)
 
-        // Fetch page from Supabase using slug directly
-        const landingPage = await getPageByCustomUsername(slug)
+        // Fetch page from Supabase using the custom username
+        const landingPage = await getPageByCustomUsername(custom_username)
 
         if (landingPage) {
           const template = getTemplateById(landingPage.template_type)
@@ -57,7 +59,7 @@ const LandingPage = () => {
             content
           })
         } else {
-          setError('Page not found')
+          setNotFound(true)
         }
       } catch (error) {
         console.error('Error loading landing page:', error)
@@ -68,7 +70,7 @@ const LandingPage = () => {
     }
 
     loadPage()
-  }, [slug])
+  }, [custom_username, username])
 
   const handleFormSubmit = async (formData) => {
     // In production, this would submit to your backend
@@ -89,12 +91,16 @@ const LandingPage = () => {
     )
   }
 
+  if (notFound) {
+    return <NotFound />
+  }
+
   if (error || !pageData) {
     return (
       <div className="min-h-screen bg-anti-flash-white flex items-center justify-center">
         <div className="text-center">
           <h1 className="text-4xl font-bold text-polynesian-blue mb-4">
-            {error || 'Page Not Found'}
+            {error || 'Error Loading Page'}
           </h1>
           <p className="text-polynesian-blue/70 mb-6">
             The landing page you're looking for doesn't exist or has been removed.

--- a/src/components/pages/NotFound.jsx
+++ b/src/components/pages/NotFound.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+import * as FiIcons from 'react-icons/fi'
+import SafeIcon from '../../common/SafeIcon'
+
+const { FiArrowLeft } = FiIcons
+
+const NotFound = () => {
+  const navigate = useNavigate()
+  return (
+    <div className="min-h-screen bg-anti-flash-white flex items-center justify-center">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold text-polynesian-blue mb-4">404 - Page Not Found</h1>
+        <p className="text-polynesian-blue/70 mb-6">The page you're looking for doesn't exist.</p>
+        <button
+          onClick={() => navigate('/')}
+          className="inline-flex items-center space-x-2 text-picton-blue hover:text-picton-blue/80 transition-colors"
+        >
+          <SafeIcon icon={FiArrowLeft} className="w-4 h-4" />
+          <span>Back to Home</span>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default NotFound


### PR DESCRIPTION
## Summary
- route landing pages from `/:custom_username` and profiles from `/profile/:username`
- fetch landing pages by custom username and show 404 when missing
- render JSONB landing page content with SEO meta tags and mobile styles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcc49358208333828a6037f97ea065