### PR TITLE
Add template gallery and configurable landing page builder

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@ import Dashboard from './components/pages/Dashboard'
 import ContentManager from './components/cms/ContentManager'
 import ProfessionalProfile from './components/dashboard/ProfessionalProfile'
 import MyLandingPages from './components/dashboard/MyLandingPages'
-import LandingPageEditor from './components/landingPages/LandingPageEditor'
+import LandingPageBuilder from './components/landingPages/LandingPageBuilder'
 import ResourcesCenter from './components/resources/ResourcesCenter'
 import LeadsLayout from './components/leads/LeadsLayout'
 import LeadsDashboard from './components/leads/LeadsDashboard'
@@ -69,7 +69,7 @@ const AppRoutes = () => {
         <Route index element={<Dashboard />} />
         <Route path="professional-profile" element={<ProfessionalProfile />} />
         <Route path="landing-pages" element={<MyLandingPages />} />
-        <Route path="landing-pages/:id/edit" element={<LandingPageEditor />} />
+        <Route path="landing-pages/:id/edit" element={<LandingPageBuilder />} />
         <Route path="resources" element={<ResourcesCenter />} />
         <Route path="blog-submission" element={<AgentBlogSubmission />} />
         

--- a/src/components/dashboard/MyLandingPages.jsx
+++ b/src/components/dashboard/MyLandingPages.jsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion'
 import { useAuth } from '../../context/AuthContext'
 import { createPage, deletePage, supabase } from '../../lib/supabase'
 import { getAllTemplates } from '../../data/landingPageTemplates'
+import TemplateGallery from '../landingPages/TemplateGallery'
 import Button from '../ui/Button'
 import Card from '../ui/Card'
 import Modal from '../ui/Modal'
@@ -65,13 +66,19 @@ const MyLandingPages = () => {
       }
 
       const selectedTemplate = availableTemplates.find(t => t.id === newPage.template_type)
+      const defaultContent = {
+        ...selectedTemplate?.defaultContent,
+        themeColor: selectedTemplate?.color,
+        layout: 'default'
+      }
 
       const pageData = {
         user_id: user.id,
         template_type: newPage.template_type,
         custom_username: customUsername,
         title: newPage.title || selectedTemplate?.name,
-        created_at: new Date().toISOString()
+        created_at: new Date().toISOString(),
+        content: JSON.stringify(defaultContent)
       }
 
       const created = await createPage(pageData)
@@ -234,34 +241,10 @@ const MyLandingPages = () => {
             <label className="block text-sm font-medium text-polynesian-blue mb-2">
               Template Type
             </label>
-            <div className="grid grid-cols-1 gap-3">
-              {availableTemplates.map((template) => (
-                <label
-                  key={template.id}
-                  className={`relative flex items-start p-4 border rounded-lg cursor-pointer hover:bg-anti-flash-white/50 transition-colors ${
-                    newPage.template_type === template.id
-                      ? 'border-picton-blue bg-picton-blue/5'
-                      : 'border-gray-200'
-                  }`}
-                >
-                  <input
-                    type="radio"
-                    name="template_type"
-                    value={template.id}
-                    checked={newPage.template_type === template.id}
-                    onChange={(e) => setNewPage(prev => ({ ...prev, template_type: e.target.value }))}
-                    className="sr-only"
-                  />
-                  <div className="flex items-start space-x-3 w-full">
-                    <div className={`w-4 h-4 rounded-full ${template.color} flex-shrink-0 mt-1`} />
-                    <div className="flex-1">
-                      <p className="font-medium text-polynesian-blue">{template.name}</p>
-                      <p className="text-sm text-polynesian-blue/70 mt-1">{template.description}</p>
-                    </div>
-                  </div>
-                </label>
-              ))}
-            </div>
+            <TemplateGallery
+              selected={newPage.template_type}
+              onSelect={(id) => setNewPage(prev => ({ ...prev, template_type: id }))}
+            />
           </div>
 
           <Input

--- a/src/components/landingPages/TemplateGallery.jsx
+++ b/src/components/landingPages/TemplateGallery.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { getAllTemplates } from '../../data/landingPageTemplates'
+
+const TemplateGallery = ({ selected, onSelect = () => {} }) => {
+  const templates = getAllTemplates()
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {templates.map(template => (
+        <div
+          key={template.id}
+          onClick={() => onSelect(template.id)}
+          className={`cursor-pointer border rounded-lg overflow-hidden hover:shadow transition-shadow ${selected === template.id ? 'ring-2 ring-picton-blue' : 'border-gray-200'}`}
+        >
+          {template.defaultContent?.heroImage && (
+            <img
+              src={template.defaultContent.heroImage}
+              alt={template.name}
+              className="w-full h-40 object-cover"
+            />
+          )}
+          <div className="p-4">
+            <h3 className="font-medium text-polynesian-blue">{template.name}</h3>
+            <p className="text-sm text-polynesian-blue/70 mt-1">{template.description}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default TemplateGallery
+


### PR DESCRIPTION
## Summary
- add `TemplateGallery` to preview and choose landing page templates
- preload selected template content when creating pages
- introduce builder for editing template content, form fields, layout and colors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcc76e52688333b805447ffee95819