### PR TITLE
refactor: consolidate landing page routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter as Router, Routes, Route, Navigate, useParams } from 'react-router-dom'
 import { AuthProvider, useAuth as useAuthContext } from './context/AuthContext'
 import { ThemeProvider } from './context/ThemeContext'
 import DashboardLayout from './components/dashboard/DashboardLayout'
@@ -46,6 +46,11 @@ const ProtectedRoute = ({ children, requireAdmin = false }) => {
   return children
 }
 
+const LegacyLandingPageRedirect = () => {
+  const { custom_username } = useParams()
+  return <Navigate to={`/pages/${custom_username}`} replace />
+}
+
 const AppRoutes = () => {
   const { user } = useAuthContext()
   
@@ -87,7 +92,8 @@ const AppRoutes = () => {
       
       {/* Public Profile & Landing Pages Routes */}
       <Route path="/profile/:username" element={<ProfilePage />} />
-      <Route path="/:custom_username" element={<LandingPage />} />
+      <Route path="/pages/:custom_username" element={<LandingPage />} />
+      <Route path="/:custom_username" element={<LegacyLandingPageRedirect />} />
     </Routes>
   )
 }

--- a/src/components/dashboard/MyLandingPages.jsx
+++ b/src/components/dashboard/MyLandingPages.jsx
@@ -115,7 +115,7 @@ const MyLandingPages = () => {
   }
 
   const generatePageUrl = (customUsername) => {
-    return `https://prosperityleaders.net/${customUsername}`
+    return `https://prosperityleaders.net/pages/${customUsername}`
   }
 
   return (

--- a/src/components/dashboard/PagesManager.jsx
+++ b/src/components/dashboard/PagesManager.jsx
@@ -83,7 +83,7 @@ const PagesManager = () => {
   }
 
   const generatePageUrl = (customUsername) => {
-    return `https://prosperityleaders.net/${customUsername}`
+    return `https://prosperityleaders.net/pages/${customUsername}`
   }
 
   return (


### PR DESCRIPTION
## Summary
- update React Router to serve landing pages at `/pages/:custom_username`
- redirect legacy `/:custom_username` URLs to the new structure
- adjust dashboard helpers to generate new landing page URLs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bccbe12de88333b0b9f9cf6df3c9e2