### PR TITLE
fix: include extensions in landing page imports

### DIFF
--- a/src/components/landingPages/LandingPageBuilder.jsx
+++ b/src/components/landingPages/LandingPageBuilder.jsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import Card from '../ui/Card'
-import Input from '../ui/Input'
-import Textarea from '../ui/Textarea'
-import Button from '../ui/Button'
-import { getPageById, updatePage } from '../../lib/supabase'
-import { getTemplateById } from '../../data/landingPageTemplates'
+import Card from '../ui/Card.jsx'
+import Input from '../ui/Input.jsx'
+import Textarea from '../ui/Textarea.jsx'
+import Button from '../ui/Button.jsx'
+import { getPageById, updatePage } from '../../lib/supabase.js'
+import { getTemplateById } from '../../data/landingPageTemplates.js'
 
 const LandingPageBuilder = () => {
   const { id } = useParams()

--- a/src/components/landingPages/LandingPageEditor.jsx
+++ b/src/components/landingPages/LandingPageEditor.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { getPageById, updatePage } from '../../lib/supabase'
-import Card from '../ui/Card'
-import Input from '../ui/Input'
-import Textarea from '../ui/Textarea'
-import Button from '../ui/Button'
+import { getPageById, updatePage } from '../../lib/supabase.js'
+import Card from '../ui/Card.jsx'
+import Input from '../ui/Input.jsx'
+import Textarea from '../ui/Textarea.jsx'
+import Button from '../ui/Button.jsx'
 
 const LandingPageEditor = () => {
   const { id } = useParams()

--- a/src/components/landingPages/LandingPageTemplate.jsx
+++ b/src/components/landingPages/LandingPageTemplate.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import * as FiIcons from 'react-icons/fi'
-import SafeIcon from '../../common/SafeIcon'
-import Button from '../ui/Button'
-import Input from '../ui/Input'
-import Textarea from '../ui/Textarea'
-import Card from '../ui/Card'
+import SafeIcon from '../../common/SafeIcon.jsx'
+import Button from '../ui/Button.jsx'
+import Input from '../ui/Input.jsx'
+import Textarea from '../ui/Textarea.jsx'
+import Card from '../ui/Card.jsx'
 
 const LandingPageTemplate = ({ template = {}, content = {}, professional = {}, onFormSubmit = () => {} }) => {
   const [formData, setFormData] = useState({})

--- a/src/components/landingPages/TemplateGallery.jsx
+++ b/src/components/landingPages/TemplateGallery.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { getAllTemplates } from '../../data/landingPageTemplates'
+import { getAllTemplates } from '../../data/landingPageTemplates.js'
 
 const TemplateGallery = ({ selected, onSelect = () => {} }) => {
   const templates = getAllTemplates()

--- a/src/components/pages/LandingPage.jsx
+++ b/src/components/pages/LandingPage.jsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
-import { getTemplateById } from '../../data/landingPageTemplates'
-import { getPageByCustomUsername } from '../../lib/supabase'
-import LandingPageTemplate from '../landingPages/LandingPageTemplate'
+import { getTemplateById } from '../../data/landingPageTemplates.js'
+import { getPageByCustomUsername } from '../../lib/supabase.js'
+import LandingPageTemplate from '../landingPages/LandingPageTemplate.jsx'
 import * as FiIcons from 'react-icons/fi'
-import SafeIcon from '../../common/SafeIcon'
-import NotFound from './NotFound'
+import SafeIcon from '../../common/SafeIcon.jsx'
+import NotFound from './NotFound.jsx'
 
 const { FiArrowLeft } = FiIcons
 


### PR DESCRIPTION
## Summary
- add explicit file extensions to landing page component imports
- ensure imports use correct casing
- verify Vite dev server serves modules without MIME type warnings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run dev` (manually verified served JS modules via curl)


------
https://chatgpt.com/codex/tasks/task_e_68bccdc111a083339cb06a896ad79ef3